### PR TITLE
set headers in Modify on ReInvite

### DIFF
--- a/lib/call-processor.js
+++ b/lib/call-processor.js
@@ -275,14 +275,18 @@ class CallProcessor {
 
       let optsSdp;
       let ackFunc;
+      let modifyOpts;
+      let contactForModify;
       if(!req.body) {
         //handle late offer reInvite by not letting the ACK be generated until we receive the sender's ACK with sdp.
-        const {sdp, ack} = await dlg.other.modify(response.sdp, {noAck:true});
+        modifyOpts = utils.makeModifyDialogOpts(req, contactForModify, true);
+        const {sdp, ack} = await dlg.other.modify(response.sdp, modifyOpts);
         optsSdp = sdp;
         ackFunc = ack;
       }
        else {
-        const sdp = await dlg.other.modify(response.sdp);
+        modifyOpts = utils.makeModifyDialogOpts(req, contactForModify, false);
+        const sdp = await dlg.other.modify(response.sdp, modifyOpts);
         optsSdp = sdp;
       }
 
@@ -304,7 +308,7 @@ class CallProcessor {
       }
       res.send(200, { body: response.sdp });
 
-      if(!req.body && !dlg.hasAckListener) {
+      if(!req.body) {
         // set listener for ACK, so that we can use that SDP to create the ACK for the other leg.
         dlg.once('ack', this._handleAck.bind(this, dlg, answer, offer, ackFunc, optsSdp, rtpEngineOpts));
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,9 +72,31 @@ function removeWebrtcAttributes(sdp) {
   return sdpArray.join('\r\n');
 }
 
+/**
+ * Function to generate the options to be passed to dialog.modify().
+ * @param req the request to use to modify the dialog
+ * @param contact optional Contact to use instead of the default
+ * @param noAck boolean identifying if the ACK should be handled outside of the modify funciton
+ * @returns modifyOpts
+ */
+ function makeModifyDialogOpts(req, contact, noAck) {
+  let  modifyOpts = { noAck: noAck };
+  
+  //Retain the P-Asserted-Identity header that BW adds on the reInvite to perform a warm transfer.
+  if (req.get('P-Asserted-Identity') && (req.get('Privacy') && (req.get('Privacy') == 'none'))){
+    modifyOpts = {
+      headers: contact ? {'Contact': contact, 'P-Asserted-Identity': req.get('P-Asserted-Identity')} :
+          {'P-Asserted-Identity': req.get('P-Asserted-Identity')},
+      noAck: noAck
+    };
+  }
+  return modifyOpts;
+}
+
 module.exports = {
   stringifyContact,
   isValidRegister, 
   makeRtpEngineOpts,
-  removeWebrtcAttributes
+  removeWebrtcAttributes,
+  makeModifyDialogOpts
 };


### PR DESCRIPTION
This goes along with the changes to the modify function in drachtio-srf:  https://github.com/drachtio/drachtio-srf/pull/111
Broadworks can be configured to add a P-Asserted-Identity header when the original remote party changes (as in the case of a warm transfer), and it is useful to maintain that header when proxying the request on so that it can be used for UI changes. 
I tried to make this as generic as possible so that it can easily be applied to other scenarios and continue to work when no additional headers are required or expected. But please suggest changes as you see fit. Thanks!