### PR TITLE
logging & timeout handling

### DIFF
--- a/lib/call-processor.js
+++ b/lib/call-processor.js
@@ -69,7 +69,7 @@ class CallProcessor {
         const response = await offer(optsOffer);
         this.logger.debug({offer: optsOffer, response}, 'initial offer to rtpengine');
         if ('ok' !== response.result) {
-          throw new Error(`failed allocating endpoint from rtpengine: ${JSON.stringify(response)}`);
+          throw new Error(`failed allocating endpoint for callID ${callid} from rtpengine: ${JSON.stringify(response)}`);
         }
         
         if ('outbound' === callDirection) {
@@ -134,7 +134,8 @@ class CallProcessor {
           this.logger.info('caller hung up');
         }
         else {
-          this.logger.error(`Error connecting call: ${err}`);
+          this.logger.error(`Error connecting call with callID ${callid}, ${err}`);
+          res.send(503);
         }
       }
     });
@@ -188,7 +189,7 @@ class CallProcessor {
         referTo = `${arr[1]}Replaces=${this.calls.get(key)}>` ;
       }
       else {
-        this.logger.error(`attended transfer but we cant find ${key}`);
+        this.logger.error(`attended transfer for callID ${req.get('Call-Id')} but we can't find ${key}`);
       }
     }
 
@@ -205,11 +206,11 @@ class CallProcessor {
         res.send(response.status, response.reason, resHeaders); 
       }
       else {
-        res.send(202);
+        res.send(response.status);
       }
          
     } catch (err) {
-      this.logger.error(err, 'Error handling REFER');
+      this.logger.error(err, `Error handling REFER for callID ${req.get('Call-Id')}`);
     }
   }
 
@@ -265,7 +266,7 @@ class CallProcessor {
       let response = await offer(optsOffer);
       if ('ok' !== response.result) {
         res.send(488);
-        throw new Error(`_onReinvite: rtpengine failed: offer: ${JSON.stringify(response)}`);
+        throw new Error(`_onReinvite ${req.get('Call-Id')}: rtpengine failed: offer: ${JSON.stringify(response)}`);
       }
       this.logger.debug({ optsOffer, response }, 'sent offer for reinvite to rtpengine');
 
@@ -296,7 +297,7 @@ class CallProcessor {
       response = await answer(optsAnswer);
       if ('ok' !== response.result) {
         res.send(488);
-        throw new Error(`_onReinvite: rtpengine failed: ${JSON.stringify(response)}`);
+        throw new Error(`_onReinvite {req.get('Call-Id')}: rtpengine failed: ${JSON.stringify(response)}`);
       }
       this.logger.debug({ optsAnswer, response }, 'sent answer for reinvite to rtpengine');
       if (JSON.stringify(answerMedia).includes('ICE\":\"remove')) {
@@ -304,13 +305,14 @@ class CallProcessor {
       }
       res.send(200, { body: response.sdp });
 
-      if(!req.body && !dlg.hasAckListener) {
+      if(!req.body) {
         // set listener for ACK, so that we can use that SDP to create the ACK for the other leg.
         dlg.once('ack', this._handleAck.bind(this, dlg, answer, offer, ackFunc, optsSdp, rtpEngineOpts));
       }
       
      } catch (err) {
-      this.logger.error(err, 'Error handling reinvite');
+      this.logger.error(err, `Error handling reinvite for callID ${req.get('Call-Id')}`);
+      res.send(503);
     }
   }
   
@@ -325,7 +327,7 @@ class CallProcessor {
    */
   async _handleAck(dlg, answer, offer, ack, offerSdp, rtpEngineOpts, req) {
     this.logger.info('Received ACK with late offer: ', req.body);
-    
+     
       try {
         let fromTag = dlg.other.sip.remoteTag;
         let toTag = dlg.other.sip.localTag;
@@ -352,7 +354,7 @@ class CallProcessor {
         //send an offer first so that rtpEngine knows that DTLS fingerprint needs to be in the answer sdp.
         let response = await offer(optsOffer);
         if ('ok' !== response.result) {
-          throw new Error(`_handleAck: rtpengine failed: offer: ${JSON.stringify(response)}`);
+          throw new Error(`_handleAck ${req.get('Call-Id')}: rtpengine failed: offer: ${JSON.stringify(response)}`);
         }
         this.logger.debug({optsOffer, response}, 'sent offer to use for ACK to rtpengine');
 
@@ -365,7 +367,7 @@ class CallProcessor {
         };
         const ackResponse = await answer(optsAnswer);
         if ('ok' !== ackResponse.result) {
-          throw new Error(`_handleAck: rtpengine failed: answer: ${JSON.stringify(ackResponse)}`);
+          throw new Error(`_handleAck ${req.get('Call-Id')}: rtpengine failed: answer: ${JSON.stringify(ackResponse)}`);
         }
         this.logger.debug({optsAnswer, ackResponse},'sent answer to rtpEngine');
         if (JSON.stringify(answerMedia).includes('ICE\":\"remove')) {
@@ -375,7 +377,7 @@ class CallProcessor {
         ack(ackResponse.sdp);
       
     } catch (err) {
-        this.logger.error(err, 'Error handling ACK');
+        this.logger.error(err, `Error handling ACK with callId ${req.get('Call-Id')}`);
     }
   }
 }
@@ -384,7 +386,7 @@ module.exports = CallProcessor ;
 
 
 function deleteProxy(del, rtpEngineIdentifyingDetails) {
-  del(rtpEngineIdentifyingDetails) ;
+  del(rtpEngineIdentifyingDetails).catch((error) => console.log('No response to rtpengine delete'));
 }
 
 function produceSdpUas(answer, opts, remoteSdp, res) {


### PR DESCRIPTION
- Added call ID to logs
- forward REFER responses
Changes to support handling an rtp engine timeout:
- send 503 on failures for INVITE and reINVITE
- catch error on delete 
